### PR TITLE
Use streams3

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
-var Readable = require('readable-stream/readable');
-var rwrap = require('readable-wrap');
+var Readable = require('readable-stream').Readable;
 
 module.exports = function (stream) {
     var opts = stream._readableState;
-    if (typeof stream.read !== 'function') stream = rwrap(stream, opts);
+    if (typeof stream.read !== 'function') {
+        stream = new Readable(opts).wrap(stream);
+    }
     
     var ro = new Readable({ objectMode: opts && opts.objectMode });
     var waiting = false;

--- a/package.json
+++ b/package.json
@@ -4,13 +4,12 @@
   "description": "wrap a readable/writable stream to be read-only",
   "main": "index.js",
   "dependencies": {
-    "readable-stream": "^1.0.31",
-    "readable-wrap": "^1.0.0"
+    "readable-stream": "^2.0.2"
   },
   "devDependencies": {
     "concat-stream": "^1.4.6",
-    "tape": "^2.13.2",
-    "through2": "~0.6.1",
+    "tape": "^4.2.0",
+    "through2": "^2.0.0",
     "through": "^2.3.4",
     "covert": "^1.0.0"
   },


### PR DESCRIPTION
* Update to readable-stream@^2.0.2
* Remove "readable-wrap" since it isn't needed anymore because the [issue] [1] it aimed to fix is now part of [streams3] [2].
* Update devDeps

[1]: joyent/node#7758
[2]: https://github.com/nodejs/readable-stream/blob/v2.0.2/lib/_stream_readable.js#L812-L816